### PR TITLE
fix: Make ore type fixed after partial mine

### DIFF
--- a/packages/experience/worlds.json
+++ b/packages/experience/worlds.json
@@ -1,5 +1,5 @@
 {
   "31337": {
-    "address": "0x1EE2839380C13EE30fda40F668bC238012343B58"
+    "address": "0x2E3148b13A5A0704c730f0dF367A9C9d8D766fFD"
   }
 }

--- a/packages/world/test/BiomesAssertions.sol
+++ b/packages/world/test/BiomesAssertions.sol
@@ -164,4 +164,12 @@ abstract contract BiomesAssertions is MudTest, GasReporter {
   function assertEq(ObjectTypeId a, ObjectTypeId b) internal pure {
     assertTrue(a == b, "");
   }
+
+  function assertNeq(ObjectTypeId a, ObjectTypeId b, string memory err) internal pure {
+    assertTrue(a != b, err);
+  }
+
+  function assertNeq(ObjectTypeId a, ObjectTypeId b) internal pure {
+    assertTrue(a != b, "");
+  }
 }

--- a/packages/world/worlds.json
+++ b/packages/world/worlds.json
@@ -1,5 +1,5 @@
 {
   "31337": {
-    "address": "0x1EE2839380C13EE30fda40F668bC238012343B58"
+    "address": "0x2E3148b13A5A0704c730f0dF367A9C9d8D766fFD"
   }
 }


### PR DESCRIPTION
- After the first mine, ore type becomes fixed
- Ore mass is now set correctly

Fixes #77 