### PR TITLE
docs: fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@
 
 - Fix access control for setting entity access group.
 - Support setting access group by smart entity programs.
-- Add overloaded functions to DefaultProgramSystem that don't recieve a caller.
+- Add overloaded functions to DefaultProgramSystem that don't receive a caller.
 
 ## 2025-07-07
 


### PR DESCRIPTION
## Summary
- fix typo "recieve" -> "receive" in CHANGELOG

## Testing
- `pnpm test` *(fails: Command "mud" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a402040f4083209924d332660f9d75